### PR TITLE
Move threading factorial to multiprocessing

### DIFF
--- a/ii/threading.examples/factorial.py
+++ b/ii/threading.examples/factorial.py
@@ -1,28 +1,29 @@
-import threading, queue
+import multiprocessing
 import math
 import sys
 import time
 
-class Factorial(threading.Thread):
 
+class Factorial(multiprocessing.Process):
     def __init__(self, n, queue):
-        threading.Thread.__init__(self)
+        multiprocessing.Process.__init__(self)
         self.n = n
         self.queue = queue
 
     def run(self):
         result = 1
-        for i in range(1, self.n+1):
+        for i in range(1, self.n + 1):
             result *= i
         self.queue.put(result)
 
-if __name__ == '__main__':
-    queue = queue.Queue()
-    thread = Factorial(int(sys.argv[1]), queue)
-    thread.start()
+
+if __name__ == "__main__":
+    queue = multiprocessing.Queue()
+    process = Factorial(int(sys.argv[1]), queue)
+    process.start()
     while queue.empty():
-        print('.', end='', file=sys.stderr)
+        print(".", end="", file=sys.stderr)
         sys.stderr.flush()
         time.sleep(0.2)
     print("Result: {0}".format(queue.get()), file=sys.stderr)
-    thread.join()
+    process.join()


### PR DESCRIPTION
python threading isn't usable and recommended for CPU bound jobs.

IO bound tasks = `threading`
CPU bound tasks = `multiprocessing`